### PR TITLE
:sparkles: Feat: 게시물 카드 구현(+ 더미 데이터) (#8)

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -5,6 +5,15 @@ const nextConfig = {
   sassOptions: {
     includePaths: [path.join(__dirname, "src", "styles")],
   },
+  images: {
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'images.unsplash.com',
+        pathname: '/**',
+      },
+    ],
+  },
 };
 
 module.exports = nextConfig;

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -13,6 +13,7 @@
         "jsonwebtoken": "^9.0.2",
         "next": "14.2.15",
         "next-swagger-doc": "^0.4.0",
+        "prop-types": "^15.8.1",
         "react": "^18",
         "react-dom": "^18",
         "react-markdown-editor-lite": "^1.3.4",

--- a/client/package.json
+++ b/client/package.json
@@ -17,6 +17,7 @@
     "jsonwebtoken": "^9.0.2",
     "next": "14.2.15",
     "next-swagger-doc": "^0.4.0",
+    "prop-types": "^15.8.1",
     "react": "^18",
     "react-dom": "^18",
     "react-markdown-editor-lite": "^1.3.4",

--- a/client/src/app/components/PostCard/PostCard.jsx
+++ b/client/src/app/components/PostCard/PostCard.jsx
@@ -1,0 +1,107 @@
+// PostCard 컴포넌트: 개별 게시물 카드 형식을 렌더링하는 컴포넌트
+// category, date, image, title, tags와 같은 속성을 받아 화면에 보여줌
+
+import React from 'react';
+import Image from 'next/image';
+import PropTypes from 'prop-types';
+import styles from './PostCard.module.scss';
+
+const PostCard = ({ category, date, image, title, tags }) => {
+  // 이미지가 없을 경우 사용할 기본 이미지 경로
+  // assets/imgs 접근 실패하여 public/favicon.png 사용
+  const DEFAULT_IMAGE = '/favicon.png';
+
+  return (
+    <div className={styles.post_card}>
+      {/* 카드 상단 부분: 카테고리, 날짜 표시 */}
+      <div className={styles.post_card_header}>
+        <span className={styles.post_card_category}>
+          <span>■</span> {category}
+        </span>
+        <span className={styles.post_card_date}>{date}</span>
+      </div>
+
+      {/* 이미지 부분: 전달된 이미지가 없을 경우 기본 이미지 사용 */}
+      <div className={styles.post_card_image_wrapper}>
+        <Image
+          className={styles.post_card_image}
+          src={image || DEFAULT_IMAGE}
+          fill
+          alt={`image of ${title}`}
+        />
+      </div>
+
+      {/* 게시글 제목 부분 */}
+      <h3 className={styles.post_card_title}>{title}</h3>
+
+      {/* 태그 부분: 각 태그의 형태를 버튼 형태로 표시 */}
+      <div className={styles.post_card_tags}>
+        {tags.map((tag, index) => (
+          <button key={index} className={styles.post_card_tag}>
+            #{tag}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+// 컴포넌트 타입 설정
+PostCard.PropTypes = {
+  category: PropTypes.string.isRequired, // 카테고리: string, 필수
+  date: PropTypes.string.isRequired, // 날짜: string, 필수
+  image: PropTypes.string, // 이미지: string, 선택
+  title: PropTypes.string.isRequired, // 제목: string, 필수
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired, // 태그 배열: string, 선택
+};
+
+// 더미 게시글 카드 데이터
+const dummyPosts = [
+  {
+    category: 'Tech',
+    date: '20 JAN 2024',
+    image:
+      'https://images.unsplash.com/photo-1633356122102-3fe601e05bd2?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    title: 'Understanding React Hooks: A Comprehensive Guide',
+    tags: ['React', 'JavaScript', 'Hooks'],
+  },
+  {
+    category: '21 JAN 2024',
+    date: '2024-10-23',
+    image: '',
+    title: '10 Tips for a Better Work-Life Balance',
+    tags: ['Life', 'Balance', 'Tips'],
+  },
+  {
+    category: '22 JAN 2024',
+    date: '2024-10-23',
+    image: '',
+    title:
+      'Exploring the Future of Quantum Computing: How This Revolutionary Technology Will Transform Industries, Solve Complex Problems, and Push the Boundaries of What’s Possible in Science, Medicine, and Artificial Intelligence',
+    tags: ['Quantum Computing', 'Technology', 'AI', 'Future', 'Complex'],
+  },
+];
+
+// PostCardsList: 더미 게시글 카드를 렌더링하기 위한 컴포넌트
+const PostCardsList = () => {
+  return (
+    <div>
+      {dummyPosts.map((post, index) => (
+        <PostCard
+          key={index}
+          category={post.category}
+          date={post.date}
+          image={post.image}
+          title={post.title}
+          tags={post.tags}
+        />
+      ))}
+    </div>
+  );
+};
+
+// 기본 내보내기(PostCard: 이 파일을 불러올 때 기본적으로 사용될 컴포넌트)
+export default PostCard;
+
+// 명시적인 내보내기(PostCardsList: 더미 게시글 카드를 출력하기 위해 명시적으로 가져올 컴포넌트)
+export { PostCardsList };

--- a/client/src/app/components/PostCard/PostCard.module.scss
+++ b/client/src/app/components/PostCard/PostCard.module.scss
@@ -1,0 +1,78 @@
+$color-teal400: #2ED3B7;
+$color-teal950: #0A2926;
+
+.post_card {
+    box-sizing: border-box;
+    border: 1px solid red;
+    position: relative;
+    width: 300px;
+    height: 100%;
+    padding: 16px 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 20px;
+    border-radius: 2px;
+    color: $color-teal950;
+    font-family: Pretendard;
+}
+
+.post_card_header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 12px;
+    line-height: 80%;
+}
+
+.post_card_category {
+    font-weight: 800;
+}
+
+.post_card_category span {
+    color: $color-teal400;
+}
+
+.post_card_date {
+    font-weight: 500;
+}
+
+.post_card_image_wrapper {
+    position: relative;
+    width: 100%;
+    height: 200px;
+}
+
+.post_card_image {
+    object-fit: cover;
+}
+
+.post_card_title {
+    width: 100%;
+    max-height: calc(23px * 3); /* 3줄에 맞게 최대 높이 설정 */
+    display: -webkit-box; /* Flexbox 대안으로 사용, 여러 줄을 처리 가능하게 함 */
+    -webkit-box-orient: vertical; /* 수직으로 텍스트 정렬 */
+    -webkit-line-clamp: 3; /* 3줄까지만 표시 */
+    overflow: hidden; /* 넘치는 부분을 숨김 */
+    text-overflow: ellipsis; /* 넘치는 텍스트를 생략 표시 */
+    word-break: keep-all; /* 단어가 중간에서 잘리는 것을 방지 */
+    font-weight: 700; /* 글자 굵기 */
+}
+
+.post_card_tags {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    flex-wrap: wrap; /* 태그가 넘칠 경우 다음 줄로 이동 */
+}
+
+.post_card_tag {
+    background-color: transparent;
+    padding: 0 6px;
+    display: flex;
+    align-items: center;
+    border: 1px dashed $color-teal950;
+    border-radius: 2px;
+    white-space: nowrap; /* 태그 내 텍스트가 줄바꿈되지 않도록 설정 */
+    font-size: 12px;
+}


### PR DESCRIPTION


## 🛠️ 구현한 기능
- 게시글 카드 컴포넌트 완성

## 📝 구현한 내용
- (체크리스트 확인)

<img width="359" alt="2024-10-30_10 14 18" src="https://github.com/user-attachments/assets/6b235eea-6bee-4ff6-b980-89bc7d09c9c5">



## ✅ 체크리스트
- [x] 카드 모양
- [x] width 300px

## 💬 리뷰 요구 사항
- prop-types 패키지 설치
- 카드 구분을 위한 빨간 테두리 추가됨, 추후 삭제 필요

## 🔗 연관된 이슈
- close #이슈번호
