### PR TITLE
✨ Feat: 프롤로그 섹션 구현 (#51)

### DIFF
--- a/client/src/app/components/MainPostCard/MainPostCard.jsx
+++ b/client/src/app/components/MainPostCard/MainPostCard.jsx
@@ -1,0 +1,90 @@
+import Image from 'next/image';
+import PropTypes from 'prop-types';
+import styles from './MainPostCard.module.scss';
+
+// 더미 데이터
+const dummyMainPosts = [
+  {
+    category: 'Tech',
+    date: '20 JAN 2024',
+    image: 'https://images.unsplash.com/photo-1633356122102-3fe601e05bd2?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    title: 'Node.js 라이브러리 백포파이프라인에 물리기',
+    description: '라이브러리 관리와 배포 프로세스를 자동화하는 방법을 상세히 설명하는 글로 라이브러리 관리에 있어 수행해야 하는 다양한 작업들을 설명합니다.',
+    tags: ['Node.js', 'Pipeline', 'Library']
+  },
+  {
+    category: 'Web',
+    date: '21 JAN 2024',
+    image: 'https://images.unsplash.com/photo-1460925895917-afdab827c52f?q=80&w=2426&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
+    title: '코어 웹 바이털(Core Web Vitals) 알아보기',
+    description: '이용자에게 실제로 제공되는 웹 경험을 체계화하여 전달하는 방법과 Google이 이를 활용하는 방식을 알아봅니다.',
+    tags: ['Web Performance', 'SEO', 'Core Web Vitals']
+  }
+];
+
+// MainPostCard 컴포넌트
+const MainPostCard = ({ post }) => {
+  const DEFAULT_IMAGE = '/favicon.png';
+
+  return (
+    <article className={styles.main_post_card}>
+      <div className={styles.content}>
+        <div className={styles.header}>
+          <span className={styles.category}>
+            <span className={styles.dot}>■</span> {post.category}
+          </span>
+          <span className={styles.date}>{post.date}</span>
+        </div>
+
+        <h2 className={styles.title}>{post.title}</h2>
+        
+        <p className={styles.description}>{post.description}</p>
+
+        <div className={styles.tags}>
+          {post.tags.map((tag, index) => (
+            <button key={index} className={styles.tag}>
+              #{tag}
+            </button>
+          ))}
+        </div>
+      </div>g
+
+      <div className={styles.image_wrapper}>
+        <Image
+          className={styles.image}
+          src={post.image || DEFAULT_IMAGE}
+          fill
+          alt={`Main post image of ${post.title}`}
+        />
+      </div>
+    </article>
+  );
+};
+
+MainPostCard.propTypes = {
+  post: PropTypes.shape({
+    category: PropTypes.string.isRequired,
+    date: PropTypes.string.isRequired,
+    image: PropTypes.string,
+    title: PropTypes.string.isRequired,
+    description: PropTypes.string.isRequired,
+    tags: PropTypes.arrayOf(PropTypes.string).isRequired
+  }).isRequired
+};
+
+// 더미데이터를 사용하는 MainPostList 컴포넌트
+const MainPostList = () => {
+  return (
+    <div className={styles.main_post_box}>
+      {dummyMainPosts.map((post, index) => (
+        <MainPostCard key={index} post={post} />
+      ))}
+    </div>
+  );
+};
+
+// 기본 내보내기: MainPostCard 컴포넌트
+export default MainPostCard;
+
+// 명시적 내보내기: MainPostList 컴포넌트와 더미데이터
+export { MainPostList, dummyMainPosts };

--- a/client/src/app/components/MainPostCard/MainPostCard.module.scss
+++ b/client/src/app/components/MainPostCard/MainPostCard.module.scss
@@ -1,0 +1,109 @@
+.main_post_box {
+    display: flex;
+    justify-content: space-between;
+    gap: 24px;
+    height: calc(100% - 50px);
+    width: 100%;
+  }
+  
+  .main_post_card {
+    display: flex;
+    gap: 24px;
+    height: 100%;
+    padding: 32px;
+    border: 1px solid #e5e7eb;
+    border-radius: 8px;
+    background-color: white;
+    transition: all 0.3s ease;
+    width: calc(50% - 12px);
+    
+    &:hover {
+      border-color: #2ED3B7;
+    }
+  }
+  
+  .content {
+    flex: 1;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+    min-width: 0;
+    max-width: calc(100% - 200px - 24px);
+  }
+  
+  .header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    font-size: 14px;
+    font-family: Pretendard;
+  }
+  
+  .category {
+    font-weight: 700;
+    color: #0A2926;
+  }
+  
+  .dot {
+    color: #2ED3B7;
+  }
+  
+  .date {
+    color: #4b5563;
+  }
+  
+  .title {
+    font-size: 24px;
+    font-weight: 700;
+    line-height: 1.4;
+    color: #0A2926;
+    font-family: Pretendard;
+    margin: 0;
+  }
+  
+  .description {
+    font-size: 16px;
+    line-height: 1.6;
+    color: #4b5563;
+    display: -webkit-box;  // 말줄임표 표시
+    -webkit-box-orient: vertical; // 텍스트 수직 방향으로 정렬
+    -webkit-line-clamp: 3; // 최대 3줄까지만 표시
+    overflow: hidden; // 넘치는 텍스트 숨김
+    font-family: Pretendard;
+    margin: 0;
+  }
+  
+  .tags {
+    display: flex;
+    gap: 4px;
+    margin-top: auto;
+    white-space: nowrap;
+  }
+  
+  .tag {
+    padding: 2px 8px;
+    border: 1px dashed #0A2926;
+    border-radius: 4px;
+    font-size: 12px;
+    color: #0A2926;
+    background: transparent;
+    transition: all 0.2s ease;
+    cursor: pointer;
+    
+    &:hover {
+      background-color: #2ED3B7;
+      border-color: #2ED3B7;
+      color: white;
+    }
+  }
+  
+  .image_wrapper {
+    position: relative;
+    width: 200px;
+    flex-shrink: 0;
+    
+    .image {
+      object-fit: cover;
+      border-radius: 4px;
+    }
+  }

--- a/client/src/app/page.jsx
+++ b/client/src/app/page.jsx
@@ -3,7 +3,9 @@
 import styles from './page.module.css';
 import { useState } from 'react';
 import Navigation from './components/navigation';
+import { PostCardsList } from './components/PostCard/PostCard';
 import Footer from './components/Footer';
+import { MainPostList } from './components/MainPostCard/MainPostCard';
 
 export default function Home() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -106,8 +108,8 @@ export default function Home() {
             <div className={styles.main_post_title}>/main post</div>
           </div>
           <div className={styles.main_post_box}>
-            <article className={styles.card}></article>
-            <article className={styles.card}></article>
+            {/* <메인 포스트 영역 */}
+            <MainPostList />
           </div>
         </div>
 
@@ -131,6 +133,7 @@ export default function Home() {
               {[...Array(6)].map((_, index) => (
                 <div key={index} className={styles.placeholder}>
                   {/* 카드 컴포넌트 영역 */}
+                  <PostCardsList></PostCardsList>
                 </div>
               ))}
             </div>

--- a/client/src/app/page.module.css
+++ b/client/src/app/page.module.css
@@ -117,10 +117,9 @@
   margin-bottom: 50px;
 }
 .placeholder {
-  background-color: #f3f4f6;
+  /* background-color: #f3f4f6; */
   border: 1px solid #e5e7eb;
   border-radius: 8px;
-  height: 400px; /* 카드 높이 고정 */
 }
 
 .footer {
@@ -178,4 +177,12 @@
   justify-content: center;
   color: #4b5563;
   font-family: 'GalmuriMono', monospace;
+}
+
+/* 더미데이터 css */
+.main_post_box {
+  display: flex;
+  justify-content: space-between;
+  gap: 24px;
+  height: calc(100% - 50px);
 }


### PR DESCRIPTION
## 🛠️ 구현한 기능
프롤로그 섹션 구현

## 📝 구현한 내용
- 메인페이지에 대표로 표시할 설정한 카테고리의 최신 포스트 2개가 표시
- 카드 컴포넌트를 2x1 배열로 정렬
![image](https://github.com/user-attachments/assets/ef036c82-1e9e-4ed7-be60-5087862a4345)

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 🔗 연관된 이슈
- close #51 
