### PR TITLE
:sparkles: Feat: 좋아요 버튼 화면 구현 ( #11 )

### DIFF
--- a/client/src/app/post/components/LikeButton.jsx
+++ b/client/src/app/post/components/LikeButton.jsx
@@ -1,0 +1,35 @@
+'use client';
+
+import React, { useState } from 'react';
+import styles from './LikeButton.module.scss';
+
+const LikeButton = () => {
+  // 좋아요 상태와 좋아요 수 관리
+  const [isLiked, setIsLiked] = useState(false);
+  const [likeCount, setLikeCount] = useState(0);
+
+  // 좋아요 버튼 클릭 핸들러
+  const handleLikeToggle = () => {
+    // 좋아요 상태 반전
+    setIsLiked(!isLiked);
+    // 좋아요 수 증가 또는 감소
+    setLikeCount((prevCount) => (isLiked ? prevCount - 1 : prevCount + 1));
+  };
+
+  return (
+    <div className={styles.like_button_container}>
+      <button className={styles.like_button} onClick={handleLikeToggle}>
+        {/* 빈 하트(좋아요 안 함)와 색 찬 하트(좋아요 함) 조건부 렌더링 */}
+        {isLiked ? (
+          <span className={styles.materialIconLikeTrue}>favorite</span>
+        ) : (
+          <span className={styles.materialIconLikeFalse}>favorite</span>
+        )}
+      </button>
+      {/* 좋아요 수 표시 */}
+      <span className={styles.like_count}>{likeCount}</span>
+    </div>
+  );
+};
+
+export default LikeButton;

--- a/client/src/app/post/components/LikeButton.module.scss
+++ b/client/src/app/post/components/LikeButton.module.scss
@@ -1,0 +1,39 @@
+@import url('https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:opsz,wght,FILL,GRAD@20..48,100..700,0..1,-50..200');
+@import url('https://fonts.googleapis.com/css2?family=Inconsolata:wght@200..900&display=swap'); // 왜 이걸 추가해야 다른 폰트에 영향을 주지 않는건지 의문..
+
+.like_button_container {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+    padding-top: 8px;
+    padding-bottom: 80px;
+}
+
+.like_button {
+    color: #2ed3b7;
+    font-size: 48px;
+    border: none;
+    background: none;
+    cursor: pointer;
+    transition: transform 0.2s;
+}
+
+.like_button:hover {
+    transform: scale(1.1);
+}
+
+.materialIconLikeTrue {
+    font-family: 'Material Symbols Outlined';
+    font-variation-settings: 'FILL' 1, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+    color: red;
+}
+
+.materialIconLikeFalse {
+    font-family: 'Material Symbols Outlined';
+    font-variation-settings: 'FILL' 0, 'wght' 400, 'GRAD' 0, 'opsz' 48;
+    color: #c9c9c9;
+}
+
+.like_count {
+    font-size: 16px;
+}

--- a/client/src/app/post/page.jsx
+++ b/client/src/app/post/page.jsx
@@ -3,6 +3,7 @@ import MarkdownIt from 'markdown-it';
 import styles from './post.module.scss';
 import CommentSection from './components/comments';
 import CopyLinkButton from './components/CopyLinkButton';
+import LikeButton from './components/LikeButton';
 
 // MarkdownIt 인스턴스 생성 (마크다운 렌더링에 사용)
 const md = new MarkdownIt();
@@ -11,6 +12,90 @@ const md = new MarkdownIt();
 const page = () => {
   // 메타데이터 태그를 확인하기 위한 더미 태그 문자열. 쉼표로 구분
   const dummyTags = '#프론트엔드,#React,#Next.js';
+
+  // 마크다운 미리보기를 확인하기 위한 더미 마크다운 텍스트
+  const dummyMarkdown = `
+# Heading 1
+## Heading 2
+### Heading 3
+#### Heading 4
+##### Heading 5
+###### Heading 6
+
+---
+
+**굵은 텍스트**  
+*기울임 텍스트*  
+***굵은 기울임 텍스트***  
+~~취소선 텍스트~~
+
+---
+
+> 이 부분은 인용문입니다.
+> > 중첩된 인용문입니다.
+
+---
+
+1. 순서가 있는 목록 첫 번째 항목
+2. 두 번째 항목
+    1. 하위 항목
+    2. 또 다른 하위 항목
+
+- 순서 없는 목록 첫 번째 항목
+- 두 번째 항목
+  - 하위 항목
+  - 또 다른 하위 항목
+
+---
+
+### 링크와 이미지
+[Google로 이동](https://www.google.com)
+
+![Markdown 로고](https://markdown-here.com/img/icon256.png)
+
+---
+
+### 코드 블록
+
+\`\`\`javascript
+// JavaScript 코드 예시
+function greet(name) {
+    return \`Hello, \${name}!\`;
+}
+console.log(greet("Markdown"));
+\`\`\`
+
+---
+
+### 인라인 코드
+여기에 \`console.log("Hello, Markdown!");\` 와 같은 인라인 코드를 사용할 수 있습니다.
+
+---
+
+### 테이블
+
+| Feature       | Description                | Status    |
+| ------------- | -------------------------- | --------- |
+| Heading       | 제목을 지정하는 방법       | 🟢 지원함 |
+| Lists         | 순서가 있는 목록과 없는 목록 | 🟢 지원함 |
+| Inline Code   | \`코드 스타일\` 지원         | 🟢 지원함 |
+| Code Blocks   | 코드 블록 표현              | 🟢 지원함 |
+
+---
+
+### 체크리스트
+
+- [x] 이 항목은 완료됨
+- [ ] 이 항목은 아직 미완료
+
+---
+
+### 수평선
+위에 내용과 아래 내용을 구분하기 위한 수평선입니다.
+
+---
+
+  `;
 
   return (
     <div className={styles.post_container}>
@@ -60,7 +145,7 @@ const page = () => {
               </tr>
             </tbody>
           </table>
-          < CopyLinkButton />
+          <CopyLinkButton />
         </div>
 
         {/* 목차 섹션: 포스트 내부의 헤딩 목록을 보여줌 */}
@@ -86,9 +171,14 @@ const page = () => {
         </div>
 
         {/* 아티클 내용: 마크다운으로 작성된 본문이 렌더링될 영역 */}
-        <article className={styles.article_content}>
+        <article
+          className={styles.article_content}
+          dangerouslySetInnerHTML={{ __html: md.render(dummyMarkdown) }}
+        >
           {/* 더미 마크다운 문서 렌더링 */}
         </article>
+        {/* 좋아요 버튼 섹션 */}
+        <LikeButton />
       </div>
 
       {/* 댓글 섹션 */}


### PR DESCRIPTION


## 🛠️ 구현한 기능
- 좋아요 버튼

## 📝 구현한 내용
- 좋아요 버튼 위치를 확인하기 위해 post에 더미 마크다운 텍스트 변수를 추가하였습니다
<img width="1440" alt="스크린샷 2024-11-01 12 19 07" src="https://github.com/user-attachments/assets/727d31c7-5a5d-4d9a-a3dd-bd6e9dba3730">
<img width="1440" alt="스크린샷 2024-11-01 12 19 13" src="https://github.com/user-attachments/assets/70ff6233-323c-44fb-9e85-797328b42480">


## ✅ 체크리스트
- [x] 방문자가 좋아요를 표시할 수 있는 버튼
- [x] 재선택 시 좋아요 입력 취소
- [x] 좋아요 수 실시간 반영

## 💬 리뷰 요구 사항
- LikeButton.module.css에 @import inconsolata 를 해야 다른 폰트에 영향을 미치지 않음...
폰트 로딩 순서에 문제가 있는 것으로 추측됨


## 🔗 연관된 이슈
- close #11
