### PR TITLE
🍻 Chore: 로그인 상태에 따라 네비게이션 분리 및 로그아웃 기능 구현 (#66)

### DIFF
--- a/client/src/app/components/navigation/index.jsx
+++ b/client/src/app/components/navigation/index.jsx
@@ -1,7 +1,7 @@
 import styles from './navigation.module.scss';
 import Link from 'next/link';
 import { Inconsolata } from 'next/font/google';
-import { useSession } from 'next-auth/react';
+import { useSession, signOut } from 'next-auth/react';
 
 const inconsolata = Inconsolata({
   subsets: ['latin'],
@@ -10,6 +10,11 @@ const inconsolata = Inconsolata({
 
 export default function Navigation() {
   const { data: session } = useSession();
+  
+// 로그아웃 완료 후 홈페이지로 이동
+  const handleLogout = async () => {
+    await signOut({ redirect: true, callbackUrl: '/' });
+  };
 
   return (
     <nav className={styles.nav}>
@@ -28,7 +33,12 @@ export default function Navigation() {
               <>
                 <Link href="/post" className={`${styles.menuItem} ${inconsolata.className}`}>[P] POSTING</Link>
                 <Link href="/setting" className={`${styles.menuItem} ${inconsolata.className}`}>[S] SETTING</Link>
-                <Link href="/" className={`${styles.menuItem} ${inconsolata.className}`}>[L] LOGOUT</Link>
+                <button 
+                  onClick={handleLogout}
+                  className={`${styles.menuItem} ${inconsolata.className} ${styles.logout_button}`}
+                >
+                  [L] LOGOUT
+                </button>
               </>
             ) : (
               // 로그인되지 않은 상태

--- a/client/src/app/components/navigation/index.jsx
+++ b/client/src/app/components/navigation/index.jsx
@@ -1,6 +1,7 @@
 import styles from './navigation.module.scss';
 import Link from 'next/link';
 import { Inconsolata } from 'next/font/google';
+import { useSession } from 'next-auth/react';
 
 const inconsolata = Inconsolata({
   subsets: ['latin'],
@@ -8,21 +9,31 @@ const inconsolata = Inconsolata({
 });
 
 export default function Navigation() {
+  const { data: session } = useSession();
+
   return (
     <nav className={styles.nav}>
       <div className="container">
         <div className={styles.navContent}>
-          {/* 왼쪽 nav */}
+          {/* 왼쪽 nav - 항상 표시 */}
           <div className={styles.leftMenu}>
-            <Link href="/"className={`${styles.menuItem} ${inconsolata.className}`}>[H] HOME</Link>
+            <Link href="/" className={`${styles.menuItem} ${inconsolata.className}`}>[H] HOME</Link>
             <Link href="/search" className={`${styles.menuItem} ${inconsolata.className}`}>[S] SEARCH</Link>
           </div>
 
-          {/* 오른쪽 nav */}
+          {/* 오른쪽 nav - 로그인 상태에 따라 다르게 표시 */}
           <div className={styles.rightMenu}>
-            <Link href="/posting" className={`${styles.menuItem} ${inconsolata.className}`}>[P] POSTING</Link>
-            <Link href="/setting" className={`${styles.menuItem} ${inconsolata.className}`}>[S] SETTING</Link>
-            <Link href="/" className={`${styles.menuItem} ${inconsolata.className}`}>[L] LOGOUT</Link>
+            {session ? (
+              // 로그인된 상태
+              <>
+                <Link href="/post" className={`${styles.menuItem} ${inconsolata.className}`}>[P] POSTING</Link>
+                <Link href="/setting" className={`${styles.menuItem} ${inconsolata.className}`}>[S] SETTING</Link>
+                <Link href="/" className={`${styles.menuItem} ${inconsolata.className}`}>[L] LOGOUT</Link>
+              </>
+            ) : (
+              // 로그인되지 않은 상태
+              <Link href="/login" className={`${styles.menuItem} ${inconsolata.className}`}>[L] LOGIN</Link>
+            )}
           </div>
         </div>
       </div>

--- a/client/src/app/components/navigation/navigation.module.scss
+++ b/client/src/app/components/navigation/navigation.module.scss
@@ -37,3 +37,9 @@
     color: #059669;
     font-weight: 600;
   }
+
+  .logout_button{
+    border: none; 
+    cursor: pointer;
+  }
+  


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 로그인 상태에 따라 네비게이션 분리 및 로그아웃 기능 구현

## 📝 구현한 내용
- 로그아웃 버튼에 로그아웃 기능 구현(버튼 클릭 시 홈페이지 이동 및 로그아웃 상태로 변경)
- 로그인 상태-> POSTING/ SETTING/LOGOUT  
![image](https://github.com/user-attachments/assets/65a32889-2f02-4a79-92eb-9b8decebe445)
- 로그아웃 상태 -> LOGIN
![image](https://github.com/user-attachments/assets/d6222ea9-9b31-425f-9b9e-0dd1de8af021)
- 추후 네비게이션 링크 변경 필요할듯

## ✅ 체크리스트
- [x] 이슈 내용 모두 적용
- [x] 작업 기간 내 개발

## 🔗 연관된 이슈
- close #66 
