### PR TITLE
Feat/#34 게시글 카드 APi 연동 완료

### DIFF
--- a/client/src/app/components/PostCard/PostCard.jsx
+++ b/client/src/app/components/PostCard/PostCard.jsx
@@ -1,27 +1,22 @@
-// PostCard 컴포넌트: 개별 게시물 카드 형식을 렌더링하는 컴포넌트
-// category, date, image, title, tags와 같은 속성을 받아 화면에 보여줌
+// src/app/components/PostCard/PostCard.jsx
 
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Image from 'next/image';
 import PropTypes from 'prop-types';
 import styles from './PostCard.module.scss';
+import { postApi } from '@/utils/api';
 
 const PostCard = ({ category, date, image, title, tags }) => {
-  // 이미지가 없을 경우 사용할 기본 이미지 경로
-  // assets/imgs 접근 실패하여 public/favicon.png 사용
   const DEFAULT_IMAGE = '/favicon.png';
 
   return (
     <div className={styles.post_card}>
-      {/* 카드 상단 부분: 카테고리, 날짜 표시 */}
       <div className={styles.post_card_header}>
         <span className={styles.post_card_category}>
           <span>■</span> {category}
         </span>
         <span className={styles.post_card_date}>{date}</span>
       </div>
-
-      {/* 이미지 부분: 전달된 이미지가 없을 경우 기본 이미지 사용 */}
       <div className={styles.post_card_image_wrapper}>
         <Image
           className={styles.post_card_image}
@@ -30,11 +25,7 @@ const PostCard = ({ category, date, image, title, tags }) => {
           alt={`image of ${title}`}
         />
       </div>
-
-      {/* 게시글 제목 부분 */}
       <h3 className={styles.post_card_title}>{title}</h3>
-
-      {/* 태그 부분: 각 태그의 형태를 버튼 형태로 표시 */}
       <div className={styles.post_card_tags}>
         {tags.map((tag, index) => (
           <button key={index} className={styles.post_card_tag}>
@@ -46,62 +37,53 @@ const PostCard = ({ category, date, image, title, tags }) => {
   );
 };
 
-// 컴포넌트 타입 설정
-PostCard.PropTypes = {
-  category: PropTypes.string.isRequired, // 카테고리: string, 필수
-  date: PropTypes.string.isRequired, // 날짜: string, 필수
-  image: PropTypes.string, // 이미지: string, 선택
-  title: PropTypes.string.isRequired, // 제목: string, 필수
-  tags: PropTypes.arrayOf(PropTypes.string).isRequired, // 태그 배열: string, 선택
+PostCard.propTypes = {
+  category: PropTypes.string.isRequired,
+  date: PropTypes.string.isRequired,
+  image: PropTypes.string,
+  title: PropTypes.string.isRequired,
+  tags: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
-// 더미 게시글 카드 데이터
-const dummyPosts = [
-  {
-    category: 'Tech',
-    date: '20 JAN 2024',
-    image:
-      'https://images.unsplash.com/photo-1633356122102-3fe601e05bd2?q=80&w=2940&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
-    title: 'Understanding React Hooks: A Comprehensive Guide',
-    tags: ['React', 'JavaScript', 'Hooks'],
-  },
-  {
-    category: '21 JAN 2024',
-    date: '2024-10-23',
-    image: '',
-    title: '10 Tips for a Better Work-Life Balance',
-    tags: ['Life', 'Balance', 'Tips'],
-  },
-  {
-    category: '22 JAN 2024',
-    date: '2024-10-23',
-    image: '',
-    title:
-      'Exploring the Future of Quantum Computing: How This Revolutionary Technology Will Transform Industries, Solve Complex Problems, and Push the Boundaries of What’s Possible in Science, Medicine, and Artificial Intelligence',
-    tags: ['Quantum Computing', 'Technology', 'AI', 'Future', 'Complex'],
-  },
-];
-
-// PostCardsList: 더미 게시글 카드를 렌더링하기 위한 컴포넌트
 const PostCardsList = () => {
+  const [posts, setPosts] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const fetchPosts = async () => {
+      try {
+        const response = await postApi.getAllPosts();
+        setPosts(Array.isArray(response) ? response : []);
+      } catch (err) {
+        console.error('Error fetching posts:', err);
+        setError('게시물을 불러오는데 실패했습니다.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchPosts();
+  }, []);
+
+  if (loading) return <div className={styles.loading}>Loading...</div>;
+  if (error) return <div className={styles.error}>{error}</div>;
+  if (!posts.length) return <div className={styles.no_posts}>게시물이 없습니다.</div>;
+
   return (
-    <div>
-      {dummyPosts.map((post, index) => (
+    <>
+      {posts.map((post) => (
         <PostCard
-          key={index}
-          category={post.category}
-          date={post.date}
-          image={post.image}
+          key={post._id}
+          category={post.categoryId?.name || 'Uncategorized'}
+          date={new Date(post.createdAt).toLocaleDateString()}
+          image={post.mainImage}
           title={post.title}
-          tags={post.tags}
+          tags={post.tags || []}
         />
       ))}
-    </div>
+    </>
   );
 };
 
-// 기본 내보내기(PostCard: 이 파일을 불러올 때 기본적으로 사용될 컴포넌트)
-export default PostCard;
-
-// 명시적인 내보내기(PostCardsList: 더미 게시글 카드를 출력하기 위해 명시적으로 가져올 컴포넌트)
-export { PostCardsList };
+export default PostCardsList;

--- a/client/src/app/components/PostCard/PostCard.jsx
+++ b/client/src/app/components/PostCard/PostCard.jsx
@@ -5,35 +5,40 @@ import Image from 'next/image';
 import PropTypes from 'prop-types';
 import styles from './PostCard.module.scss';
 import { postApi } from '@/utils/api';
+import Link from 'next/link';
 
-const PostCard = ({ category, date, image, title, tags }) => {
+const PostCard = ({ postId, category, date, image, title, tags }) => {
   const DEFAULT_IMAGE = '/favicon.png';
 
   return (
-    <div className={styles.post_card}>
-      <div className={styles.post_card_header}>
-        <span className={styles.post_card_category}>
-          <span>■</span> {category}
-        </span>
-        <span className={styles.post_card_date}>{date}</span>
+    <Link href={`/post/${postId}`}>
+      <div className={styles.post_card}>
+        <div className={styles.post_card_header}>
+          <span className={styles.post_card_category}>
+            <span>■</span> {category}
+          </span>
+          <span className={styles.post_card_date}>{date}</span>
+        </div>
+        <div className={styles.post_card_image_wrapper}>
+          <Image
+            className={styles.post_card_image}
+            src={image || DEFAULT_IMAGE}
+            fill
+            alt={`image of ${title}`}
+          />
+        </div>
+        <h3 className={styles.post_card_title}>
+          <Link href={`/post/${postId}`}>{title}</Link>
+        </h3>
+        <div className={styles.post_card_tags}>
+          {tags.map((tag, index) => (
+            <button key={index} className={styles.post_card_tag}>
+              #{tag}
+            </button>
+          ))}
+        </div>
       </div>
-      <div className={styles.post_card_image_wrapper}>
-        <Image
-          className={styles.post_card_image}
-          src={image || DEFAULT_IMAGE}
-          fill
-          alt={`image of ${title}`}
-        />
-      </div>
-      <h3 className={styles.post_card_title}>{title}</h3>
-      <div className={styles.post_card_tags}>
-        {tags.map((tag, index) => (
-          <button key={index} className={styles.post_card_tag}>
-            #{tag}
-          </button>
-        ))}
-      </div>
-    </div>
+    </Link>
   );
 };
 
@@ -68,13 +73,15 @@ const PostCardsList = () => {
 
   if (loading) return <div className={styles.loading}>Loading...</div>;
   if (error) return <div className={styles.error}>{error}</div>;
-  if (!posts.length) return <div className={styles.no_posts}>게시물이 없습니다.</div>;
+  if (!posts.length)
+    return <div className={styles.no_posts}>게시물이 없습니다.</div>;
 
   return (
     <>
       {posts.map((post) => (
         <PostCard
           key={post._id}
+          postId={post._id}
           category={post.categoryId?.name || 'Uncategorized'}
           date={new Date(post.createdAt).toLocaleDateString()}
           image={post.mainImage}

--- a/client/src/app/components/PostCard/PostCard.module.scss
+++ b/client/src/app/components/PostCard/PostCard.module.scss
@@ -3,7 +3,6 @@ $color-teal950: #0A2926;
 
 .post_card {
     box-sizing: border-box;
-    border: 1px solid red;
     position: relative;
     width: 300px;
     height: 100%;

--- a/client/src/app/page.jsx
+++ b/client/src/app/page.jsx
@@ -1,11 +1,11 @@
 'use client';
 
 import styles from './page.module.css';
-import { useState } from 'react';  
+import { useState } from 'react';
 import Navigation from './components/navigation';
 import Footer from './components/Footer';
 import { MainPostList } from './components/MainPostCard/MainPostCard';
-import { PostCardsList } from './components/PostCard/PostCard';
+import PostCardsList from './components/PostCard/PostCard';
 
 export default function Home() {
   const [currentPage, setCurrentPage] = useState(1);
@@ -95,9 +95,10 @@ export default function Home() {
             <span>거북목</span>의 하루
           </h2>
           <p className={styles.description}>
-            거북목 팀의 블로그에 오신것을 환영합니다.<br />
-            지금까지 보지못한 멋진 기술 블로그를 구현할<br />수 있다는 것을
-            보여드리겠습니다
+            거북목 팀의 블로그에 오신것을 환영합니다.
+            <br />
+            지금까지 보지못한 멋진 기술 블로그를 구현할
+            <br />수 있다는 것을 보여드리겠습니다
           </p>
         </div>
 
@@ -127,11 +128,7 @@ export default function Home() {
               <h2 className={styles.feedTitle}>/Feed</h2>
             </div>
             <div className={styles.grid}>
-              {[...Array(6)].map((_, index) => (
-                <div key={index} className={styles.placeholder}>
-                  <PostCardsList></PostCardsList>
-                </div>
-              ))}
+              <PostCardsList />
             </div>
 
             {/* 페이지네이션 */}

--- a/client/src/app/page.module.css
+++ b/client/src/app/page.module.css
@@ -90,7 +90,7 @@
 
 /* Feed 섹션 */
 .feedSection {
-  flex: 1;
+  width: 100%;
   min-height: 900px;
 }
 
@@ -107,20 +107,15 @@
 }
 
 .grid {
-  flex: 1; /* 남은 공간 모두 차지 */
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  grid-template-rows: repeat(2, 1fr); /* 2행 지정 */
-  gap: 24px;
-  padding: 32px 0;
-  margin-top: auto;
-  margin-bottom: 50px;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr)); 
+  grid-auto-rows: auto;
+  gap: 32px;
+  width: 100%;
+  box-sizing: border-box;
 }
-.placeholder {
-  /* background-color: #f3f4f6; */
-  border: 1px solid #e5e7eb;
-  border-radius: 8px;
-}
+
+
 
 .footer {
   padding: 32px 0;

--- a/client/src/utils/api.js
+++ b/client/src/utils/api.js
@@ -98,3 +98,105 @@ export const likeApi = {
     });
   },
 };
+
+export const commentApi = {
+  // 댓글 생성
+  createComment: async ({ postId, content, isAdmin, nickname, password }) => {
+    const commentData = isAdmin
+      ? {
+          postId,
+          content,
+          isAdmin: true,
+          nickname, // 세션에서 가져온 관리자 닉네임
+        }
+      : {
+          postId,
+          content,
+          isAdmin: false,
+          nickname,
+          password,
+        };
+
+    return fetchApi(`/api/comment/${postId}`, {
+      method: 'POST',
+      body: JSON.stringify(commentData),
+    });
+  },
+
+  // 게시글의 모든 댓글 조회
+  getComments: async (postId) => {
+    return fetchApi(`/api/comment/${postId}`);
+  },
+
+  // 나머지는 그대로 유지
+  updateComment: async (commentId, { content, password }) => {
+    return fetchApi(`/api/comment/${commentId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({
+        content,
+        password,
+      }),
+    });
+  },
+
+  deleteComment: async (commentId, password) => {
+    return fetchApi(`/api/comment/${commentId}`, {
+      method: 'DELETE',
+      body: JSON.stringify({ password }),
+    });
+  },
+};
+
+export const categoryApi = {
+  // 기존 카테고리 목록 조회 유지
+  getCategories: async () => {
+    return fetchApi('/api/category', {
+      method: 'GET',
+    });
+  },
+
+  // 특정 카테고리 조회
+  getCategory: async (categoryId) => {
+    return fetchApi(`/api/category/${categoryId}`, {
+      method: 'GET',
+    });
+  },
+
+  // 새 카테고리 생성 (전체 목록 반환)
+  createCategory: async (name) => {
+    return fetchApi('/api/category', {
+      method: 'POST',
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  // 카테고리 수정 (전체 목록 반환)
+  updateCategory: async (categoryId, name) => {
+    return fetchApi(`/api/category/${categoryId}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ name }),
+    });
+  },
+
+  // 카테고리 삭제 (전체 목록 반환)
+  deleteCategory: async (categoryId) => {
+    return fetchApi(`/api/category/${categoryId}`, {
+      method: 'DELETE',
+    });
+  },
+};
+
+export const adminApi = {
+  // 관리자 설정 조회
+  getAdminSettings: () => {
+    return fetchApi('/api/admin');
+  },
+
+  // 관리자 설정 업데이트 (닉네임, 블로그 이름, 블로그 설명)
+  updateSetting: (type, value) => {
+    return fetchApi(`/api/admin/${type}`, {
+      method: 'PATCH',
+      body: JSON.stringify({ [type]: value }),
+    });
+  },
+};


### PR DESCRIPTION
## 🛠️ 구현한 기능
- 게시글 카드 카드 API 연동

## 📝 구현한 내용
- 메인 페이지에서 모든 게시물을 조회하여 카드로 표시
- 카드 클릭시 해당 게시글로 상세 보기 이동

## ✅ 체크리스트

## 💬 리뷰 요구 사항
- 페이지네이션과 필터 연결 필요

## 🔗 연관된 이슈
- close #34 
